### PR TITLE
chore: add PHPDoc blocks

### DIFF
--- a/src/EventDispatcher.php
+++ b/src/EventDispatcher.php
@@ -5,10 +5,25 @@ namespace AndrewDyer\EventDispatcher;
 use AndrewDyer\EventDispatcher\Events\EventInterface;
 use AndrewDyer\EventDispatcher\Listeners\ListenerInterface;
 
+/**
+ * Dispatches events to their registered listeners.
+ */
 class EventDispatcher
 {
+    /**
+     * Registered listeners indexed by event name.
+     *
+     * @var array<string, list<ListenerInterface>>
+     */
     protected array $listeners = [];
 
+    /**
+     * Adds a listener for the given event name.
+     *
+     * @param string $eventName The name of the event to listen for.
+     * @param ListenerInterface $listener The listener to register.
+     * @return self The dispatcher instance.
+     */
     public function addListener(string $eventName, ListenerInterface $listener): self
     {
         $this->listeners[$eventName][] = $listener;
@@ -16,6 +31,11 @@ class EventDispatcher
         return $this;
     }
 
+    /**
+     * Dispatches an event to all registered listeners.
+     *
+     * @param EventInterface $event The event to dispatch.
+     */
     public function dispatch(EventInterface $event): void
     {
         $eventName = $event->getName();
@@ -24,11 +44,22 @@ class EventDispatcher
         }
     }
 
+    /**
+     * Returns all registered listeners.
+     *
+     * @return array<string, list<ListenerInterface>> All listeners indexed by event name.
+     */
     public function getListeners(): array
     {
         return $this->listeners;
     }
 
+    /**
+     * Returns all listeners registered for the given event name.
+     *
+     * @param string $eventName The name of the event.
+     * @return list<ListenerInterface> The listeners registered for the event.
+     */
     public function getListenersByEvent(string $eventName): array
     {
         if (!$this->hasListeners($eventName)) {
@@ -38,6 +69,12 @@ class EventDispatcher
         return $this->listeners[$eventName];
     }
 
+    /**
+     * Determines whether any listeners are registered for the given event name.
+     *
+     * @param string $eventName The name of the event.
+     * @return bool True if at least one listener is registered, false otherwise.
+     */
     public function hasListeners(string $eventName): bool
     {
         return isset($this->listeners[$eventName]);

--- a/src/EventDispatcher.php
+++ b/src/EventDispatcher.php
@@ -73,7 +73,7 @@ class EventDispatcher
      * Determines whether any listeners are registered for the given event name.
      *
      * @param string $eventName The name of the event.
-     * @return bool True if at least one listener is registered, false otherwise.
+     * @return bool True if a listener registry entry exists for the event, false otherwise.
      */
     public function hasListeners(string $eventName): bool
     {

--- a/src/Events/AbstractEvent.php
+++ b/src/Events/AbstractEvent.php
@@ -2,8 +2,16 @@
 
 namespace AndrewDyer\EventDispatcher\Events;
 
+/**
+ * Provides a base implementation of EventInterface.
+ */
 abstract class AbstractEvent implements EventInterface
 {
+    /**
+     * Returns the short class name as the default event name.
+     *
+     * @return string The short (unqualified) class name of the event.
+     */
     public function getName(): string
     {
         return (new \ReflectionClass($this))->getShortName();

--- a/src/Events/EventInterface.php
+++ b/src/Events/EventInterface.php
@@ -2,7 +2,15 @@
 
 namespace AndrewDyer\EventDispatcher\Events;
 
+/**
+ * Defines the contract for an event.
+ */
 interface EventInterface
 {
+    /**
+     * Returns the event name.
+     *
+     * @return string The event name.
+     */
     public function getName(): string;
 }

--- a/src/Listeners/AbstractListener.php
+++ b/src/Listeners/AbstractListener.php
@@ -4,7 +4,15 @@ namespace AndrewDyer\EventDispatcher\Listeners;
 
 use AndrewDyer\EventDispatcher\Events\EventInterface;
 
+/**
+ * Provides a base implementation of ListenerInterface.
+ */
 abstract class AbstractListener implements ListenerInterface
 {
+    /**
+     * Handles the given event.
+     *
+     * @param EventInterface $event The event to handle.
+     */
     abstract public function handle(EventInterface $event): void;
 }

--- a/src/Listeners/ListenerInterface.php
+++ b/src/Listeners/ListenerInterface.php
@@ -2,6 +2,9 @@
 
 namespace AndrewDyer\EventDispatcher\Listeners;
 
+/**
+ * Defines the contract for an event listener.
+ */
 interface ListenerInterface
 {
 }

--- a/tests/EventDispatcherTest.php
+++ b/tests/EventDispatcherTest.php
@@ -8,8 +8,14 @@ use AndrewDyer\EventDispatcher\Tests\Fixtures\Listeners\AnotherDummyListener;
 use AndrewDyer\EventDispatcher\Tests\Fixtures\Listeners\DummyListener;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Unit tests for EventDispatcher.
+ */
 class EventDispatcherTest extends TestCase
 {
+    /**
+     * Asserts that a listener can be added to the dispatcher.
+     */
     public function testCanAddListenerToDispatcher(): void
     {
         $eventDispatcher = new EventDispatcher();
@@ -21,6 +27,9 @@ class EventDispatcherTest extends TestCase
         $this->assertCount(1, $listeners);
     }
 
+    /**
+     * Asserts that the dispatcher correctly reports when no listeners are registered for an event.
+     */
     public function testCanCheckIfDispatcherHasListenerRegisteredForEvent()
     {
         $eventDispatcher = new EventDispatcher();
@@ -28,6 +37,9 @@ class EventDispatcherTest extends TestCase
         $this->assertFalse($eventDispatcher->hasListeners('DummyEvent'));
     }
 
+    /**
+     * Asserts that listeners can be retrieved by event name.
+     */
     public function testCanGetListenersByEventName(): void
     {
         $eventDispatcher = new EventDispatcher();
@@ -39,6 +51,9 @@ class EventDispatcherTest extends TestCase
         $this->assertCount(1, $listeners);
     }
 
+    /**
+     * Asserts that an empty array is returned when no listeners are registered for an event.
+     */
     public function testDispatcherReturnsEmptyArrayIfNoListenersSetForEvent(): void
     {
         $eventDispatcher = new EventDispatcher();
@@ -49,6 +64,9 @@ class EventDispatcherTest extends TestCase
         $this->assertCount(0, $listeners);
     }
 
+    /**
+     * Asserts that the dispatcher calls the listener's handle method when an event is dispatched.
+     */
     public function testDispatcherCanDispatchAnEvent()
     {
         $event = new DummyEvent();
@@ -61,6 +79,9 @@ class EventDispatcherTest extends TestCase
         $eventDispatcher->dispatch($event);
     }
 
+    /**
+     * Asserts that the dispatcher calls every listener's handle method when an event is dispatched to multiple listeners.
+     */
     public function testDispatcherCanDispatchAnEventWithMultipleListeners()
     {
         $event = new DummyEvent();

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -6,8 +6,14 @@ use AndrewDyer\EventDispatcher\Tests\Fixtures\Events\AnotherDummyEvent;
 use AndrewDyer\EventDispatcher\Tests\Fixtures\Events\DummyEvent;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Unit tests for AbstractEvent.
+ */
 class EventTest extends TestCase
 {
+    /**
+     * Asserts that an event returns its short class name as the default event name.
+     */
     public function testEventHasDefaultNameIfNotSet()
     {
         $event = new DummyEvent();
@@ -15,6 +21,9 @@ class EventTest extends TestCase
         $this->assertEquals('DummyEvent', $event->getName());
     }
 
+    /**
+     * Asserts that an event returns the overridden name when getName is implemented.
+     */
     public function testCanGetNameOfEvent(): void
     {
         $event = new AnotherDummyEvent();

--- a/tests/Fixtures/Events/AnotherDummyEvent.php
+++ b/tests/Fixtures/Events/AnotherDummyEvent.php
@@ -4,8 +4,16 @@ namespace AndrewDyer\EventDispatcher\Tests\Fixtures\Events;
 
 use AndrewDyer\EventDispatcher\Events\AbstractEvent;
 
+/**
+ * Dispatched when a dummy test event with a custom name is triggered.
+ */
 class AnotherDummyEvent extends AbstractEvent
 {
+    /**
+     * Returns the custom event name.
+     *
+     * @return string The custom event name.
+     */
     #[\Override]
     public function getName(): string
     {

--- a/tests/Fixtures/Events/DummyEvent.php
+++ b/tests/Fixtures/Events/DummyEvent.php
@@ -4,6 +4,9 @@ namespace AndrewDyer\EventDispatcher\Tests\Fixtures\Events;
 
 use AndrewDyer\EventDispatcher\Events\AbstractEvent;
 
+/**
+ * Dispatched when a dummy test event is triggered.
+ */
 class DummyEvent extends AbstractEvent
 {
 }

--- a/tests/Fixtures/Listeners/AnotherDummyListener.php
+++ b/tests/Fixtures/Listeners/AnotherDummyListener.php
@@ -5,8 +5,16 @@ namespace AndrewDyer\EventDispatcher\Tests\Fixtures\Listeners;
 use AndrewDyer\EventDispatcher\Events\EventInterface;
 use AndrewDyer\EventDispatcher\Listeners\AbstractListener;
 
+/**
+ * Handles another dummy test event.
+ */
 class AnotherDummyListener extends AbstractListener
 {
+    /**
+     * Handles the given event.
+     *
+     * @param EventInterface $event The event to handle.
+     */
     #[\Override]
     public function handle(EventInterface $event): void
     {

--- a/tests/Fixtures/Listeners/DummyListener.php
+++ b/tests/Fixtures/Listeners/DummyListener.php
@@ -5,8 +5,16 @@ namespace AndrewDyer\EventDispatcher\Tests\Fixtures\Listeners;
 use AndrewDyer\EventDispatcher\Events\EventInterface;
 use AndrewDyer\EventDispatcher\Listeners\AbstractListener;
 
+/**
+ * Handles a dummy test event.
+ */
 class DummyListener extends AbstractListener
 {
+    /**
+     * Handles the given event.
+     *
+     * @param EventInterface $event The event to handle.
+     */
     #[\Override]
     public function handle(EventInterface $event): void
     {

--- a/tests/ListenerTest.php
+++ b/tests/ListenerTest.php
@@ -6,8 +6,14 @@ use AndrewDyer\EventDispatcher\Tests\Fixtures\Events\DummyEvent;
 use AndrewDyer\EventDispatcher\Tests\Fixtures\Listeners\DummyListener;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Unit tests for AbstractListener.
+ */
 class ListenerTest extends TestCase
 {
+    /**
+     * Asserts that the handle method accepts a valid event instance.
+     */
     public function testHandleMethodAcceptsAnEvent()
     {
         $listener = new DummyListener();
@@ -17,6 +23,9 @@ class ListenerTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
+    /**
+     * Asserts that the handle method throws a TypeError when a non-event argument is passed.
+     */
     public function testHandleMethodThrowsErrorIfInvalidEventGiven()
     {
         $this->expectException(\TypeError::class);


### PR DESCRIPTION
This pull request introduces comprehensive PHPDoc documentation to the core event dispatcher classes, listeners, events, and their associated unit tests. These comments clarify the responsibilities, parameters, and return values of the main methods and classes, improving code readability and maintainability.

**Documentation improvements:**

* `src/EventDispatcher.php`, `src/Events/AbstractEvent.php`, `src/Events/EventInterface.php`, `src/Listeners/AbstractListener.php`, `src/Listeners/ListenerInterface.php`: Added detailed PHPDoc blocks to all classes and methods, describing their purpose, parameters, and return types. This includes all public methods such as `addListener`, `dispatch`, `getListeners`, `getListenersByEvent`, and `hasListeners`. [[1]](diffhunk://#diff-23337325005fc6b1a54b75897ffcace816ca1b9516632bfb782e5529826c018dR8-R38) [[2]](diffhunk://#diff-23337325005fc6b1a54b75897ffcace816ca1b9516632bfb782e5529826c018dR47-R62) [[3]](diffhunk://#diff-23337325005fc6b1a54b75897ffcace816ca1b9516632bfb782e5529826c018dR72-R77) [[4]](diffhunk://#diff-8b20ea26eedaa59dff29359598385277bf64f2843d28a19273e5e63384298181R5-R14) [[5]](diffhunk://#diff-474e8924c34b04d014a633d0e74e1fb8ccfe1c04fcf32a72d482ed019233fb27R5-R14) [[6]](diffhunk://#diff-eba92c77e85ad0eb6ef129663d8e9df8fce1d833a236ce4128c7c63b6f601559R7-R16) [[7]](diffhunk://#diff-2b919da09c306f8150e0de5ad25242d46d57defd5730b2158f675ef2a594f015R5-R7)

* `tests/EventDispatcherTest.php`, `tests/EventTest.php`, `tests/ListenerTest.php`: Added PHPDoc blocks to all test classes and test methods, describing the purpose of each test and clarifying assertions. [[1]](diffhunk://#diff-d0d7e02a1d3639caf5298e329c722158c772546916a818eab0764f93b58e6341R11-R18) [[2]](diffhunk://#diff-d0d7e02a1d3639caf5298e329c722158c772546916a818eab0764f93b58e6341R30-R42) [[3]](diffhunk://#diff-d0d7e02a1d3639caf5298e329c722158c772546916a818eab0764f93b58e6341R54-R56) [[4]](diffhunk://#diff-d0d7e02a1d3639caf5298e329c722158c772546916a818eab0764f93b58e6341R67-R69) [[5]](diffhunk://#diff-d0d7e02a1d3639caf5298e329c722158c772546916a818eab0764f93b58e6341R82-R84) [[6]](diffhunk://#diff-992da55e98d4a45ccc65fd6bd00f06e8b86b78a09e8cd92f296aa7113c8f308bR9-R26) [[7]](diffhunk://#diff-851b7b98aad2c63ae233307378200dbe3824d308b5bf73a02fb54a0e690806a9R9-R16) [[8]](diffhunk://#diff-851b7b98aad2c63ae233307378200dbe3824d308b5bf73a02fb54a0e690806a9R26-R28)

* `tests/Fixtures/Events/DummyEvent.php`, `tests/Fixtures/Events/AnotherDummyEvent.php`, `tests/Fixtures/Listeners/DummyListener.php`, `tests/Fixtures/Listeners/AnotherDummyListener.php`: Added class-level and method-level PHPDoc comments to all event and listener fixtures used in tests. [[1]](diffhunk://#diff-551d0957bf6b7525f1b9f8035ef5bc5d0ca26496d13f29ffc65858bfbc8562e3R7-R9) [[2]](diffhunk://#diff-5f82641515d10f11a5e7aeab8585a5ab0a6caad47485eb6429b821677d19ce0cR7-R16) [[3]](diffhunk://#diff-f5023d84c724bb4f37851e00095d20cb9d0686fdf9214d8da632b1bce22cb1e2R8-R17) [[4]](diffhunk://#diff-209b519cce515a782fcd20c790a9d8a42ababbad595bf2359f6e75bc87888e7fR8-R17)

No functional or behavioral changes were made; all updates are strictly related to code documentation for better developer experience.